### PR TITLE
remove an edge when there's cycles

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ function toposort(graph) {
   let s = sources(g);
   let l = [];
 
+  for (let c of g.cycles()) {
+    g.removeExistingEdge(c.pop(), c.shift())
+  }
+
   while (s.length) {
     let n = s.shift(); // vs pop?
     l.push(n);
@@ -26,10 +30,6 @@ function toposort(graph) {
         s.push(m);
       }
     }
-  }
-
-  if (g.edgeCount()) {
-    throw new Error('cycle detected in graph, topological sort is impossible');
   }
 
   return l;

--- a/test/index.js
+++ b/test/index.js
@@ -13,17 +13,16 @@ describe('toposort(graph)', function () {
     assert.isArray(toposort(graph));
   });
 
-  it('should throw when the graph has a cycle', function () {
-    // a -> b -> c -> b* (cycle)
+  it('should handle graphs that have a cycle', function () {
+    // a -> b -> c -> d -> b* (cycle)
     var graph = new Graph(
       [ [ 'a', 'b' ] ],
       [ [ 'b', 'c' ] ],
-      [ [ 'c', 'b' ] ]
+      [ [ 'c', 'd' ] ],
+      [ [ 'd', 'b' ] ]
     );
 
-    assert.throws(function () {
-      toposort(graph);
-    });
+    assert.deepEqual(toposort(graph), ['a', 'b', 'c', 'd'])
   });
 
   it('should correctly sort a simple tree', function () {


### PR DESCRIPTION
Okay I wanted to offer a solution. I haven't thought about all the possibilities here, but I _think_ this would work.

Basically grab all the cycles, and remove the edge that completes the cycle, before doing the topological sort.

I've tested this on an app with cyclical dependencies and it seems to work fine. Unfortunately there are other parts of mako that throw with cycles, so they'll need to be updated too.
